### PR TITLE
:children_crossing: adding a script to show all teams IP

### DIFF
--- a/infra/team/show-all-team-shell.sh
+++ b/infra/team/show-all-team-shell.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+gcloud auth activate-service-account \
+  --project=${PROJECT_ID} --key-file=account.json
+
+PROJECTS=$(gcloud projects list --format='value(project_id)')
+
+for p in $PROJECTS; do
+        gcloud compute instances list --project $p --filter=name:shell --format="table[no-heading](tags.items[1],name,networkInterfaces[0].accessConfigs[0].natIP)"
+done


### PR DESCRIPTION
Example output:
```bash
$ ./show-all-team-shell.sh 
Activated service account credentials for: [terraform@kubernetes-security-workshop.iam.gserviceaccount.com]
team4  shell  35.205.122.44
team3  shell
team1  shell
```